### PR TITLE
fix: Enhance AZD workflows and tag handling in deployment scripts

### DIFF
--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -1,5 +1,8 @@
 name: AZD Template Validation
 on:
+  push:
+    branches:
+      - psl-pk-azdtemplatevalidation
   schedule:
     - cron: '30 1 * * 4' # Every Thursday at 7:00 AM IST (1:30 AM UTC)
   workflow_dispatch:

--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -1,8 +1,5 @@
 name: AZD Template Validation
 on:
-  push:
-    branches:
-      - psl-pk-azdtemplatevalidation
   schedule:
     - cron: '30 1 * * 4' # Every Thursday at 7:00 AM IST (1:30 AM UTC)
   workflow_dispatch:

--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -1,5 +1,8 @@
 name: AZD Template Validation
 on:
+  push:
+    branches:
+      - psl-pk-azdtemplatevalidation
   schedule:
     - cron: '30 1 * * 4' # Every Thursday at 7:00 AM IST (1:30 AM UTC)
   workflow_dispatch:
@@ -16,6 +19,9 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set timestamp
+        run: echo "HHMM=$(date -u +'%H%M')" >> $GITHUB_ENV
 
       - name: Azure CLI Login
         uses: azure/login@v2
@@ -34,7 +40,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
+          AZURE_ENV_NAME: azd-${{ vars.AZURE_ENV_NAME }}-${{ env.HHMM }}
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -1,0 +1,47 @@
+name: AZD Template Validation
+on:
+  push:
+    branches:
+      - psl-pk-azdtemplatevalidation
+  schedule:
+    - cron: '30 1 * * 4' # Every Thursday at 7:00 AM IST (1:30 AM UTC)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
+jobs:
+  template_validation:
+    runs-on: ubuntu-latest
+    name: azd template validation
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Azure CLI Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: microsoft/template-validation-action@v0.4.3
+        with:
+          validateAzd: ${{ vars.TEMPLATE_VALIDATE_AZD }}
+          validateTests: ${{ vars.TEMPLATE_VALIDATE_TESTS }}
+          useDevContainer: ${{ vars.TEMPLATE_USE_DEV_CONTAINER }}
+        id: validation
+        env:
+          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+          AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: print result
+        if: always()
+        run: cat ${{ steps.validation.outputs.resultFile }}

--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -41,7 +41,7 @@ jobs:
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DAGA_POSTPROVISION_TAGS: ${{ vars.DAGA_POSTPROVISION_TAGS || 'defender,foundry' }}
+          DAGA_POSTPROVISION_TAGS: ${{ vars.DAGA_POSTPROVISION_TAGS }}
 
       - name: print result
         if: always()

--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -41,6 +41,7 @@ jobs:
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAGA_POSTPROVISION_TAGS: ${{ vars.DAGA_POSTPROVISION_TAGS || 'defender,foundry' }}
 
       - name: print result
         if: always()

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -23,6 +23,7 @@ jobs:
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       AZURE_DEV_COLLECT_TELEMETRY: ${{ vars.AZURE_DEV_COLLECT_TELEMETRY }}
+      DAGA_POSTPROVISION_TAGS: ${{ vars.DAGA_POSTPROVISION_TAGS }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -1,37 +1,56 @@
-name: Azure Template Validation
+name: Azure Dev Deploy
 
 on:
+  push:
+    branches:
+      - psl-pk-azdtemplatevalidation
   workflow_dispatch:
-  schedule:
-    # Run weekly on Sundays at midnight UTC
-    - cron: '0 0 * * 0'
 
 permissions:
   contents: read
   id-token: write
-  pull-requests: write
 
 jobs:
-  template_validation_job:
+  deploy:
     runs-on: ubuntu-latest
-    name: Validate Template Standards
-    environment: azd-template-gallery
+    environment: production
+    env:
+      AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
+      AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+      AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      AZURE_DEV_COLLECT_TELEMETRY: ${{ vars.AZURE_DEV_COLLECT_TELEMETRY }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
-      - uses: microsoft/template-validation-action@Latest
-        id: validation
+      - name: Install azd
+        uses: Azure/setup-azd@v2
+
+      - name: Login to Azure
+        uses: azure/login@v2
         with:
-          validateAzd: ${{ vars.AZD_VALIDATE || 'false' }}
-          useDevContainer: ${{ vars.AZD_USE_DEV_CONTAINER || 'false' }}
-        env:
-          AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
-          AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-          AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
-          AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: print result
-        if: always()
-        run: cat ${{ steps.validation.outputs.resultFile }}
+      - name: Login to AZD
+        shell: bash
+        run: |
+          azd auth login \
+            --client-id "$AZURE_CLIENT_ID" \
+            --federated-credential-provider "github" \
+            --tenant-id "$AZURE_TENANT_ID"
+
+      - name: Provision and Deploy
+        shell: bash
+        run: |
+          if ! azd env select "$AZURE_ENV_NAME"; then
+            azd env new "$AZURE_ENV_NAME" --subscription "$AZURE_SUBSCRIPTION_ID" --location "$AZURE_LOCATION" --no-prompt
+          fi
+          azd config set defaults.subscription "$AZURE_SUBSCRIPTION_ID"
+          azd env set AZURE_ENV_OPENAI_LOCATION="$AZURE_ENV_OPENAI_LOCATION"
+          azd up --no-prompt

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -1,9 +1,6 @@
 name: Azure Dev Deploy
 
 on:
-  push:
-    branches:
-      - psl-pk-azdtemplatevalidation
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -1,6 +1,9 @@
 name: Azure Dev Deploy
 
 on:
+  push:
+    branches:
+      - psl-pk-azdtemplatevalidation
   workflow_dispatch:
 
 permissions:
@@ -15,7 +18,6 @@ jobs:
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-      AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
       AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,6 +26,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Set timestamp and env name
+        run: |
+          HHMM=$(date -u +'%H%M')
+          echo "AZURE_ENV_NAME=azd-${{ vars.AZURE_ENV_NAME }}-${HHMM}" >> $GITHUB_ENV
 
       - name: Install azd
         uses: Azure/setup-azd@v2

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -54,5 +54,4 @@ jobs:
             azd env new "$AZURE_ENV_NAME" --subscription "$AZURE_SUBSCRIPTION_ID" --location "$AZURE_LOCATION" --no-prompt
           fi
           azd config set defaults.subscription "$AZURE_SUBSCRIPTION_ID"
-          azd env set AZURE_ENV_OPENAI_LOCATION="$AZURE_ENV_OPENAI_LOCATION"
           azd up --no-prompt

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -41,21 +41,6 @@ function ConvertTo-TagArray {
   return @($deduped)
 }
 
-function Add-TagSource {
-  param(
-    [System.Collections.Generic.List[object]]$Target,
-    [object]$Source
-  )
-  if (-not $Target) { return }
-  if ($null -eq $Source) { return }
-  if ($Source -is [System.Collections.IEnumerable] -and $Source -isnot [string]) {
-    foreach ($item in $Source) {
-      Add-TagSource -Target $Target -Source $item
-    }
-    return
-  }
-  $Target.Add($Source) | Out-Null
-}
 
 function Restore-StrictMode {
   param([object]$PreviousValue)
@@ -181,12 +166,16 @@ if (-not (Test-Path -Path $specPath)) {
 $paramTags = Get-ParamArray 'dagaTags'
 $envTags = Get-Default -value $env:DAGA_POSTPROVISION_TAGS -fallback $null
 
+# Filter out null/whitespace entries so empty values don't short-circuit the priority chain
+$Tags = @($Tags | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+$paramTags = if ($paramTags) { @($paramTags | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }) } else { @() }
+
 # Priority chain: CLI -Tags > DAGA_POSTPROVISION_TAGS env var > bicep dagaTags param > fallback
-if ($Tags -and $Tags.Count -gt 0) {
+if ($Tags.Count -gt 0) {
   $tagArray = ConvertTo-TagArray -tagInput $Tags
 } elseif (-not [string]::IsNullOrWhiteSpace($envTags)) {
   $tagArray = ConvertTo-TagArray -tagInput $envTags
-} elseif ($paramTags -and $paramTags.Count -gt 0) {
+} elseif ($paramTags.Count -gt 0) {
   $tagArray = ConvertTo-TagArray -tagInput $paramTags
 } else {
   $tagArray = ConvertTo-TagArray -tagInput $null

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -19,9 +19,7 @@ function ConvertTo-TagArray {
   param([object]$tagInput)
   $items = @()
   if ($null -eq $tagInput) {
-    # Safe default when no tags are resolved (e.g. bicep CLI not on PATH in CI).
-    # Local devs with bicep get the full list from main.bicepparam; override via DAGA_POSTPROVISION_TAGS.
-    return @('defender', 'foundry')
+    return @('foundation', 'dspm', 'defender', 'foundry')
   }
   if ($tagInput -isnot [System.Collections.IEnumerable] -or $tagInput -is [string]) {
     $tagInput = @($tagInput)
@@ -37,7 +35,7 @@ function ConvertTo-TagArray {
     $items += ($text -split '[,\s]+' | Where-Object { $_ })
   }
   if (-not $items) {
-    return @('defender','foundry')
+    return @('foundation', 'dspm', 'defender', 'foundry')
   }
   $deduped = $items | ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -Unique
   return @($deduped)
@@ -88,6 +86,11 @@ function Get-BicepParameterConfig {
     $json = & $bicepCmd.Source build-params $ParamFile --stdout 2>$null
     if (-not $json) { return $bag }
     $doc = $json | ConvertFrom-Json
+    # Newer Bicep CLI wraps output as { parametersJson: "<json string>", ... }
+    $paramJsonProp = $doc.PSObject.Properties['parametersJson']
+    if ($paramJsonProp -and $paramJsonProp.Value) {
+      $doc = $paramJsonProp.Value | ConvertFrom-Json
+    }
     $parametersProp = $doc.PSObject.Properties['parameters']
     if ($parametersProp -and $parametersProp.Value) {
       foreach ($prop in $parametersProp.Value.PSObject.Properties) {

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -19,7 +19,9 @@ function ConvertTo-TagArray {
   param([object]$tagInput)
   $items = @()
   if ($null -eq $tagInput) {
-    return @('foundation', 'dspm', 'defender', 'foundry')
+    # Safe default when no tags are resolved (e.g. bicep CLI not on PATH in CI).
+    # Local devs with bicep get the full list from main.bicepparam; override via DAGA_POSTPROVISION_TAGS.
+    return @('defender', 'foundry')
   }
   if ($tagInput -isnot [System.Collections.IEnumerable] -or $tagInput -is [string]) {
     $tagInput = @($tagInput)
@@ -35,7 +37,7 @@ function ConvertTo-TagArray {
     $items += ($text -split '[,\s]+' | Where-Object { $_ })
   }
   if (-not $items) {
-    return @('foundation','dspm','defender','foundry')
+    return @('defender','foundry')
   }
   $deduped = $items | ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -Unique
   return @($deduped)

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -179,12 +179,22 @@ if (-not (Test-Path -Path $specPath)) {
 }
 
 $paramTags = Get-ParamArray 'dagaTags'
-$combinedTags = New-Object 'System.Collections.Generic.List[object]'
-Add-TagSource -Target $combinedTags -Source $Tags
 $envTags = Get-Default -value $env:DAGA_POSTPROVISION_TAGS -fallback $null
-if (-not [string]::IsNullOrWhiteSpace($envTags)) { Add-TagSource -Target $combinedTags -Source $envTags }
-Add-TagSource -Target $combinedTags -Source $paramTags
-$tagArray = ConvertTo-TagArray -tagInput ($combinedTags.ToArray())
+
+# Priority chain: CLI -Tags > DAGA_POSTPROVISION_TAGS env var > bicep dagaTags param > fallback
+if ($Tags -and $Tags.Count -gt 0) {
+  $tagArray = ConvertTo-TagArray -tagInput $Tags
+  Write-Host "Using tags from CLI parameter: [$($tagArray -join ', ')]" -ForegroundColor Green
+} elseif (-not [string]::IsNullOrWhiteSpace($envTags)) {
+  $tagArray = ConvertTo-TagArray -tagInput $envTags
+  Write-Host "Using tags from DAGA_POSTPROVISION_TAGS: [$($tagArray -join ', ')]" -ForegroundColor Green
+} elseif ($paramTags -and $paramTags.Count -gt 0) {
+  $tagArray = ConvertTo-TagArray -tagInput $paramTags
+  Write-Host "Using tags from bicep parameters: [$($tagArray -join ', ')]" -ForegroundColor Green
+} else {
+  $tagArray = ConvertTo-TagArray -tagInput $null
+  Write-Host "Using default tags: [$($tagArray -join ', ')]" -ForegroundColor Green
+}
 $connectM365 = $ConnectM365.IsPresent
 if (-not $connectM365 -and $env:DAGA_POSTPROVISION_CONNECT_M365) {
   [bool]::TryParse($env:DAGA_POSTPROVISION_CONNECT_M365, [ref]$connectM365) | Out-Null

--- a/hooks/postprovision.ps1
+++ b/hooks/postprovision.ps1
@@ -184,16 +184,12 @@ $envTags = Get-Default -value $env:DAGA_POSTPROVISION_TAGS -fallback $null
 # Priority chain: CLI -Tags > DAGA_POSTPROVISION_TAGS env var > bicep dagaTags param > fallback
 if ($Tags -and $Tags.Count -gt 0) {
   $tagArray = ConvertTo-TagArray -tagInput $Tags
-  Write-Host "Using tags from CLI parameter: [$($tagArray -join ', ')]" -ForegroundColor Green
 } elseif (-not [string]::IsNullOrWhiteSpace($envTags)) {
   $tagArray = ConvertTo-TagArray -tagInput $envTags
-  Write-Host "Using tags from DAGA_POSTPROVISION_TAGS: [$($tagArray -join ', ')]" -ForegroundColor Green
 } elseif ($paramTags -and $paramTags.Count -gt 0) {
   $tagArray = ConvertTo-TagArray -tagInput $paramTags
-  Write-Host "Using tags from bicep parameters: [$($tagArray -join ', ')]" -ForegroundColor Green
 } else {
   $tagArray = ConvertTo-TagArray -tagInput $null
-  Write-Host "Using default tags: [$($tagArray -join ', ')]" -ForegroundColor Green
 }
 $connectM365 = $ConnectM365.IsPresent
 if (-not $connectM365 -and $env:DAGA_POSTPROVISION_CONNECT_M365) {


### PR DESCRIPTION
## Purpose
This pull request restructures the CI/CD workflows and improves tag handling in the post-provisioning script. The main changes include splitting template validation into its own workflow, updating the deployment workflow for better Azure Dev integration, and refining how tags are prioritized and processed in `postprovision.ps1`.

**CI/CD Workflow Restructuring:**

* Added a new `.github/workflows/azd-template-validation.yml` workflow to handle AZD template validation on a scheduled basis and via manual dispatch, including Azure login and template validation steps.
* Refactored `.github/workflows/azure-dev.yml` to focus solely on deployment, removing validation steps and adding explicit steps for Azure and AZD login, environment selection, and deployment with `azd up`.

**Post-Provisioning Script Improvements:**

* Updated `Get-BicepParameterConfig` in `postprovision.ps1` to support newer Bicep CLI output formats by handling the `parametersJson` property if present.
* Refined tag processing logic in `postprovision.ps1` to prioritize tags in the following order: CLI `-Tags` parameter, `DAGA_POSTPROVISION_TAGS` environment variable, Bicep `dagaTags` parameter, and fallback to null. This ensures the correct tags are used during provisioning.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No