### PR TITLE
chore: Improve Azure deployment scripts and update deployment guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2] - 2026-04-06
+
+### Fixed
+
+- Made the bootstrap deployment name unique per `azd` environment (`daga-bootstrap-noop-<env>`) to prevent `InvalidDeploymentLocation` errors when redeploying to a different Azure region.
+- Switched `Connect-ExchangeOnline` to device-code flow (`-Device`) so interactive M365 authentication works from containers and Codespaces.
+
 ## [1.1] - 2026-03-09
 
 ### Added

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -237,7 +237,22 @@ See the complete [Spec Field Reference](./spec-local-reference.md) for detailed 
 
 ---
 
-## 4. Configure azd parameters (optional)
+## 4. Configure Microsoft 365 environment variables
+
+If your deployment includes Fabric sensitivity labels or M365 compliance steps, set the following `azd` environment variables so the post-provision hook can authenticate to Exchange Online:
+
+```powershell
+azd env set DAGA_POSTPROVISION_CONNECT_M365 true
+azd env set DAGA_POSTPROVISION_M365_UPN "<add-your-upn>"
+```
+
+Replace `<add-your-upn>` with your Microsoft 365 user principal name (e.g., `admin@contoso.onmicrosoft.com`).
+
+In containers or Codespaces, authentication uses device-code flow — the terminal will display a URL and code for you to open on a local browser to complete sign-in.
+
+---
+
+## 5. Configure azd parameters (optional)
 
 `infra/main.bicepparam` mirrors hook inputs. Update these values if you want `azd` to pass different tags or Microsoft 365 options to `run.ps1`:
 
@@ -257,7 +272,7 @@ Environment variables (`DAGA_SPEC_PATH`, `DAGA_POSTPROVISION_TAGS`, etc.) overri
 
 ---
 
-## 5. Install AZ modules (Optional)
+## 6. Install AZ modules (Optional)
 
 If you don't have the required Azure PowerShell modules installed, run the following commands to install them:
 
@@ -279,7 +294,7 @@ These modules enable the PowerShell automation scripts to interact with Azure se
 
 ---
 
-## 6. Deploy with `azd up`
+## 7. Deploy with `azd up`
 
 ```powershell
 azd up
@@ -299,7 +314,7 @@ Run `./run.ps1 -Tags m365 -ConnectM365 -M365UserPrincipalName <upn>` from a work
 
 ---
 
-## 7. Post-deployment actions
+## 8. Post-deployment actions
 
 1. **Purview portal toggles** – enable *Secure interactions for enterprise AI apps* in the Purview portal (Data Security Posture Management for AI > Recommendations).
 2. **Role assignments** – ensure the operator account has the Audit Reader (or Compliance Administrator) role before running the audit export scripts.
@@ -313,7 +328,7 @@ For a portal-by-portal validation checklist after provisioning, see [Post-Provis
 
 ---
 
-## 8. Next steps
+## 9. Next steps
 
 - Customize the spec for additional Foundry projects or Fabric workspaces.
 - Integrate the accelerator into CI/CD by invoking `run.ps1` from GitHub Actions or Azure DevOps.

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -41,7 +41,7 @@ Gather this information before configuring your spec file:
 - [ ] **Purview Data Security AI Content Viewer** role for accessing AI prompts
 - [ ] **Microsoft 365 E5 or E5 Compliance license** (for m365 tag)
 - [ ] **Compliance Administrator** role in Microsoft 365 (for Unified Audit and DLP)
-- [ ] **Exchange Online admin** access from MFA-capable workstation (for m365 tag)
+- [ ] **Exchange Online admin** access with MFA (for m365 tag). In containers/Codespaces, device-code flow is used — open the URL shown in the terminal on a local browser to authenticate
 
 ---
 

--- a/docs/TroubleshootingGuide.md
+++ b/docs/TroubleshootingGuide.md
@@ -13,7 +13,7 @@ Use this guide to resolve common issues when running the Data Agent Governance a
 | \"Cannot find property 'tenantId'\" | Your spec.local.json has invalid JSON syntax - validate with `Get-Content ./spec.local.json | ConvertFrom-Json` |
 | Scripts skip with \"No X configured\" | The corresponding spec section is empty/missing - this is OK if you don't need that feature |
 | \"Authorization denied\" on audit exports | You need Audit Reader or Compliance Administrator role in Purview |
-| Exchange Online commands fail | Run `m365` tag from desktop with MFA, not from containers/Codespaces |
+| Exchange Online commands fail | `Connect-ExchangeOnline` now uses device-code flow (`-Device`) so it works in containers/Codespaces. Open the URL printed in the terminal on a local browser and enter the code to authenticate |
 
 ---
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,5 +1,8 @@
 targetScope = 'subscription'
 
+@description('Name of the azd environment (auto-populated by azd).')
+param environmentName string
+
 @description('Deployment location for the no-op bootstrap deployment used to satisfy azd infrastructure validation.')
 param deploymentLocation string = deployment().location
 
@@ -38,7 +41,7 @@ param dagaM365CertificatePassword string = ''
 // azd preflight rejects an ARM template with zero resources. This nested deployment is intentionally
 // inert and exists only so azd can validate and invoke the post-provision hook-driven automation.
 resource bootstrapNoOp 'Microsoft.Resources/deployments@2024-03-01' = {
-	name: 'daga-bootstrap-noop'
+	name: 'daga-bootstrap-noop-${environmentName}'
 	location: deploymentLocation
 	properties: {
 		mode: 'Incremental'

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -16,7 +16,7 @@ param dagaConnectM365 = true
 
 // Interactive Microsoft 365 auth for the m365 workflow.
 // Use this when an operator can complete browser-based sign-in and MFA.
-param dagaM365UserPrincipalName = 'v-saswatoc@MngEnvMCAP993385.onmicrosoft.com'
+param dagaM365UserPrincipalName = ''
 
 // App-only Microsoft 365 auth for the m365 workflow.
 // These are NOT used for Azure deployment itself. They are only passed to run.ps1

--- a/infra/main.bicepparam
+++ b/infra/main.bicepparam
@@ -1,5 +1,8 @@
 using './main.bicep'
 
+// Auto-populated by azd from the current environment name.
+param environmentName = readEnvironmentVariable('AZURE_ENV_NAME', 'default')
+
 // Customize these values per azd environment. The hook reads them and forwards the
 // resolved configuration to run.ps1, so no additional environment variables are required.
 param dagaSpecPath = './spec.local.json'
@@ -13,7 +16,7 @@ param dagaConnectM365 = true
 
 // Interactive Microsoft 365 auth for the m365 workflow.
 // Use this when an operator can complete browser-based sign-in and MFA.
-param dagaM365UserPrincipalName = ''
+param dagaM365UserPrincipalName = 'v-saswatoc@MngEnvMCAP993385.onmicrosoft.com'
 
 // App-only Microsoft 365 auth for the m365 workflow.
 // These are NOT used for Azure deployment itself. They are only passed to run.ps1

--- a/run.ps1
+++ b/run.ps1
@@ -231,7 +231,7 @@ foreach ($step in $selected) {
       $useInteractiveM365 = -not [string]::IsNullOrWhiteSpace($M365UserPrincipalName)
       if ($useInteractiveM365) {
         Write-Host "Connecting to Exchange Online for compliance cmdlets..." -ForegroundColor Cyan
-        Connect-ExchangeOnline -UserPrincipalName $M365UserPrincipalName -ShowBanner:$false -CommandName $exoCmds | Out-Null
+        Connect-ExchangeOnline -UserPrincipalName $M365UserPrincipalName -ShowBanner:$false -CommandName $exoCmds -Device | Out-Null
         Write-Host "Connecting to Security & Compliance PowerShell..." -ForegroundColor Cyan
         Connect-IPPSSession -UserPrincipalName $M365UserPrincipalName -ShowBanner:$false | Out-Null
       } else {


### PR DESCRIPTION
## Purpose
This pull request introduces important fixes and documentation improvements to support robust multi-environment Azure deployments and enhance Microsoft 365 authentication, especially for containerized and Codespaces scenarios. The main changes are the introduction of unique bootstrap deployment names per environment, switching Exchange Online authentication to device-code flow, and updating documentation to reflect these improvements.

**Deployment reliability and authentication improvements:**

* The bootstrap deployment in `infra/main.bicep` now uses a unique name per `azd` environment (`daga-bootstrap-noop-<env>`), preventing `InvalidDeploymentLocation` errors when redeploying to different Azure regions. This is enabled by adding the `environmentName` parameter, which is auto-populated in `infra/main.bicepparam`. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R3-R5) [[2]](diffhunk://#diff-c274a6091f4ca06948f0fe1ab8681ec4eb6b4e98c4be09717a2e3cacd1344727R3-R5) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L41-R44) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R11)
* `Connect-ExchangeOnline` in `run.ps1` now uses device-code flow (`-Device`), allowing interactive Microsoft 365 authentication to work seamlessly from containers and Codespaces. [[1]](diffhunk://#diff-3fb898b29d93c9fd71da24df805f5db2d434da7474eb08c61888c9e39d51974fL234-R234) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R11)

**Documentation updates and guidance:**

* The deployment guide (`docs/DeploymentGuide.md`) has been updated to explain the new environment variable for Exchange Online authentication, clarify the device-code flow process, and renumber deployment steps for clarity. [[1]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cL44-R44) [[2]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cL240-R255) [[3]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cL260-R275) [[4]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cL282-R297) [[5]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cL302-R317) [[6]](diffhunk://#diff-5a9feaaa3fe70489e88e08725db341b9dafb6a4185d382bba81c4093aaaded7cL316-R331)
* The troubleshooting guide (`docs/TroubleshootingGuide.md`) now reflects the new authentication method for Exchange Online, instructing users on device-code flow in containers and Codespaces.

**Changelog:**

* All of the above changes are documented in the `CHANGELOG.md` under version 1.2.* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
