### PR TITLE
fix: Add additional Az modules to Initialize-AutomationEnvironment function

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -58,7 +58,11 @@ function Initialize-AutomationEnvironment {
     @{ Name = "Az.Accounts";            MinimumVersion = "5.0.0" },
     @{ Name = "Az.Resources";           MinimumVersion = $null },
     @{ Name = "Az.Monitor";             MinimumVersion = $null },
-    @{ Name = "Az.OperationalInsights"; MinimumVersion = $null }
+    @{ Name = "Az.OperationalInsights"; MinimumVersion = $null },
+    @{ Name = "Az.Purview";             MinimumVersion = $null },
+    @{ Name = "Az.Security";            MinimumVersion = $null },
+    @{ Name = "Az.Storage";             MinimumVersion = $null },
+    @{ Name = "Az.KeyVault";            MinimumVersion = $null }
   )
   if ($RequireExchange) {
     $moduleSpecs += @{ Name = "ExchangeOnlineManagement"; MinimumVersion = $null }


### PR DESCRIPTION
## Purpose
This pull request updates the `Initialize-AutomationEnvironment` function in `run.ps1` to expand the set of required Azure PowerShell modules. The main change is the addition of several Azure modules to ensure broader support for automation tasks.

**Added Azure PowerShell modules:**

* Added `Az.Purview` to support data governance and cataloging operations.
* Added `Az.Security` to enable security management capabilities.
* Added `Az.Storage` for interacting with Azure Storage resources.
* Added `Az.KeyVault` to manage secrets, certificates, and keys.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
