### PR TITLE
fix(run.ps1): remove orphan PSScriptAnalyzer suppression comment

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -195,7 +195,6 @@ Write-Host "Running steps for tags: $($Tags -join ', ')" -ForegroundColor Cyan
 
 $fabricLabelsConfigured = Test-HasFabricLakehouseSensitivityLabels -Path $SpecPath
 
-# PSScriptAnalyzerSuppressMessage("PSAvoidAssignmentToAutomaticVariable", "", "No automatic variables are assigned; parameters are tracked via local ordered hashtable")
 foreach ($step in $selected) {
   if ($step.File -eq "scripts/governance/dspmPurview/26-Apply-FabricLakehouseSensitivity.ps1" -and -not $fabricLabelsConfigured) {
     Write-Host "Skipping Fabric lakehouse label apply step because no lakehouse sensitivity labels are configured in spec." -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary
Removes a misleading orphan `# PSScriptAnalyzerSuppressMessage(...)` comment in `run.ps1` (line 198). PSScriptAnalyzer **does not** honor comment-based suppression — only the `[Diagnostics.CodeAnalysis.SuppressMessageAttribute()]` attribute on a `param` block is recognized. The comment therefore did nothing, and the rule it claimed to suppress (`PSAvoidAssignmentToAutomaticVariable`) does not actually fire in this file.

This resolves the AI code-quality finding flagged on `run.ps1`.

## Why not the AI's suggested fix?
The AI suggestion proposed inserting:
```powershell
[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidAssignmentToAutomaticVariable', '', Justification='...')]
```
as a free-standing statement before a `foreach` loop. That is **invalid PowerShell** — `SuppressMessageAttribute` must decorate a `param(...)` block of a script or function. Adopting the suggestion would have introduced a parse error.

## Validation (local)
| Check | Before | After |
|---|---|---|
| `Parser.ParseFile` errors | 0 | **0** |
| `Invoke-ScriptAnalyzer` findings on `run.ps1` | 18 | **18** (unchanged — confirms the suppression was dead) |
| `PSAvoidAssignmentToAutomaticVariable` reported | no | no |

## Diff
```diff
- # PSScriptAnalyzerSuppressMessage("PSAvoidAssignmentToAutomaticVariable", "", "No automatic variables are assigned; parameters are tracked via local ordered hashtable")
```