### PR TITLE
chore: main to dev downmerge

### DIFF
--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -1,10 +1,6 @@
 name: Azure Dev Deploy
 
 on:
-  push:
-    branches:
-      - main
-
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Deploy this solution to your Azure subscription using the Azure Developer CLI.
 
 > **Note:** This solution accelerator requires Azure Developer CLI (azd) version 1.9.0 or higher. Please ensure you have the latest version installed before proceeding with deployment. [Download azd here](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd).
 
+> **Note:** This solution accelerator also requires **Bicep CLI version 0.33.0 or higher** for compiling infrastructure templates. [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install).
+
 [Click here to launch the deployment guide](./docs/DeploymentGuide.md)
 
 | [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/microsoft/Data-Agent-Governance-and-Security-Accelerator) | [![Open in Dev Containers](https://img.shields.io/static/v1?style=for-the-badge&label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/Data-Agent-Governance-and-Security-Accelerator) |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Make sure you have:
 - Azure CLI 2.58.0+
 - Azure Developer CLI (azd) 1.9.0+
 - PowerShell 7.x with Az modules
+- Bicep CLI 0.33.0+
 - Access to the target Azure subscription and Purview account
 - Microsoft 365 compliance permissions if you plan to run `m365`
 

--- a/docs/AlternativeDeploymentPaths.md
+++ b/docs/AlternativeDeploymentPaths.md
@@ -115,6 +115,7 @@ For organizations that only need to govern Microsoft Foundry projects without fu
 - Azure Contributor RBAC on the subscription containing your Foundry projects
 - PowerShell 7.x and Az modules installed
 - Azure Developer CLI (azd) 1.9.0+ and Azure CLI 2.58.0+
+- Bicep CLI 0.33.0+
 
 ### Minimal spec file
 

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -13,7 +13,7 @@ Before starting, confirm you have the following ready:
 | Tool | Minimum Version | Check Command | Install Link |
 |------|-----------------|---------------|---------------|
 | Azure Developer CLI (azd) | 1.9.0+ | `azd version` | [Install azd](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) |
-| Bicep CLI | 0.33.0+ | `az bicep version` | [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) |
+| Bicep CLI | 0.33.0+ | `bicep --version` | [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) |
 | Azure CLI | 2.58.0+ | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | PowerShell | 7.x | `pwsh --version` | [Install PowerShell](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) |
 | Az PowerShell modules | Latest | `Get-Module Az -ListAvailable` | `Install-Module Az -Scope CurrentUser -Force` |

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -13,6 +13,7 @@ Before starting, confirm you have the following ready:
 | Tool | Minimum Version | Check Command | Install Link |
 |------|-----------------|---------------|---------------|
 | Azure Developer CLI (azd) | 1.9.0+ | `azd version` | [Install azd](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) |
+| Bicep CLI | 0.33.0+ | `bicep --version` | [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) |
 | Azure CLI | 2.58.0+ | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | PowerShell | 7.x | `pwsh --version` | [Install PowerShell](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) |
 | Az PowerShell modules | Latest | `Get-Module Az -ListAvailable` | `Install-Module Az -Scope CurrentUser -Force` |

--- a/docs/DeploymentGuide.md
+++ b/docs/DeploymentGuide.md
@@ -13,7 +13,7 @@ Before starting, confirm you have the following ready:
 | Tool | Minimum Version | Check Command | Install Link |
 |------|-----------------|---------------|---------------|
 | Azure Developer CLI (azd) | 1.9.0+ | `azd version` | [Install azd](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd) |
-| Bicep CLI | 0.33.0+ | `bicep --version` | [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) |
+| Bicep CLI | 0.33.0+ | `az bicep version` | [Install Bicep](https://learn.microsoft.com/azure/azure-resource-manager/bicep/install) |
 | Azure CLI | 2.58.0+ | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | PowerShell | 7.x | `pwsh --version` | [Install PowerShell](https://learn.microsoft.com/powershell/scripting/install/installing-powershell) |
 | Az PowerShell modules | Latest | `Get-Module Az -ListAvailable` | `Install-Module Az -Scope CurrentUser -Force` |


### PR DESCRIPTION
Down-merge from main to dev to sync the latest changes (v1.0.4 release fixes, deployment workflow restriction, Bicep CLI documentation).

### Commits included
- fix: restrict deploy workflow to manual trigger only (#52)
- docs: Bicep CLI version pinning prerequisites (#49)
- chore: dev to main merge (v1.0.3)

Fast-forward merge \u2014 no conflicts.