### PR TITLE
fix: dependabot package upgrades

### DIFF
--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -31,7 +31,7 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: microsoft/template-validation-action@v0.4.3
+      - uses: microsoft/template-validation-action@v0.4.4
         with:
           validateAzd: ${{ vars.TEMPLATE_VALIDATE_AZD }}
           validateTests: ${{ vars.TEMPLATE_VALIDATE_TESTS }}

--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get changed markdown files (PR only)
         id: changed-markdown-files
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **/*.md


### PR DESCRIPTION
## Purpose
Upgrade Dependabot-recommended packages to resolve known vulnerabilities.

## Changes
### GitHub Actions (workflow files)
| Action | From | To | File |
|--------|------|-----|------|
| microsoft/template-validation-action | v0.4.3 | v0.4.4 | `.github/workflows/azd-template-validation.yml` |
| tj-actions/changed-files | v47.0.5 (SHA `22103cc`) | v47.0.6 (SHA `9426d40`) | `.github/workflows/broken-links-checker.yml` |

## Breaking Changes Fixed
None — both are patch-level bumps within the same major version.

## Packages Deferred
None.

## Validation
- All 8 other actions in PR #40's group are already at-or-above target versions on `dependabotchanges` (transitively covered by prior down-merges from main/dev).
- Workflow CI runs will validate on PR.

## Reporting Summary
- GitHub Actions upgraded: **2**
- Frontend / Python / NPM: N/A (repo is an azd-based Bicep template, no app code)
- **Total: 2**

## Related Dependabot PRs
- #40: build: bump the all-actions group across 1 directory with 10 updates (8 of 10 already covered transitively; this PR addresses the remaining 2)
