### PR TITLE
fix: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/azd-template-validation.yml
+++ b/.github/workflows/azd-template-validation.yml
@@ -19,19 +19,19 @@ jobs:
     name: azd template validation
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set timestamp
         run: echo "HHMM=$(date -u +'%H%M')" >> $GITHUB_ENV
 
       - name: Azure CLI Login
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: microsoft/template-validation-action@v0.4.4
+      - uses: microsoft/template-validation-action@bae4895d0a8abd4f0d5aad68ae8647b3027f4c91 # v0.4.4
         with:
           validateAzd: ${{ vars.TEMPLATE_VALIDATE_AZD }}
           validateTests: ${{ vars.TEMPLATE_VALIDATE_TESTS }}

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -22,7 +22,7 @@ jobs:
       DAGA_POSTPROVISION_TAGS: ${{ vars.DAGA_POSTPROVISION_TAGS }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set timestamp and env name
         run: |
@@ -30,10 +30,10 @@ jobs:
           echo "AZURE_ENV_NAME=azd-${{ vars.AZURE_ENV_NAME }}-${HHMM}" >> $GITHUB_ENV
 
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@0b7e3a35ab00f2eee7080c845eb39c3f0ebfa553 # v2
 
       - name: Login to Azure
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/broken-links-checker.yml
+++ b/.github/workflows/broken-links-checker.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
       - name: Check Broken Links in Changed Markdown Files
         id: lychee-check-pr
         if: github.event_name == 'pull_request' && steps.changed-markdown-files.outputs.any_changed == 'true'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://
@@ -47,7 +47,7 @@ jobs:
       - name: Check Broken Links in All Markdown Files in Entire Repo (Manual Trigger)
         id: lychee-check-manual
         if: github.event_name == 'workflow_dispatch'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: >
             --verbose --no-progress --exclude ^https?://

--- a/.github/workflows/daga-automation-oidc.yml
+++ b/.github/workflows/daga-automation-oidc.yml
@@ -27,10 +27,10 @@ jobs:
       HAS_M365_CERT: ${{ secrets.DAGA_M365_CERT_PFX != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Azure login (federated)
-        uses: azure/login@v3
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/powershell-analyzer.yml
+++ b/.github/workflows/powershell-analyzer.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Run PSScriptAnalyzer
-        uses: microsoft/psscriptanalyzer-action@v1.1
+        uses: microsoft/psscriptanalyzer-action@6b2948b1944407914a58661c49941824d149734f # v1.1
         with:
           path: ./
           recurse: true
@@ -34,7 +34,7 @@ jobs:
           # Severity levels: Error, Warning, Information
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           sarif_file: results.sarif
         if: always()
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/.github/workflows/pr-title-checker.yml
+++ b/.github/workflows/pr-title-checker.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'merge_group' }}
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark Stale Issues and PRs
-        uses: actions/stale@v10
+        uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           stale-issue-message: "This issue is stale because it has been open 180 days with no activity. Remove stale label or comment, or it will be closed in 30 days."
           stale-pr-message: "This PR is stale because it has been open 180 days with no activity. Please update or it will be closed in 30 days."
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0  # Fetch full history for accurate branch checks
       - name: Fetch All Branches
@@ -75,7 +75,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload CSV Report of Inactive Branches
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: merged-branches-report
           path: merged_branches_report.csv


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request updates several GitHub Actions workflows to use specific commit SHAs instead of version tags for their actions. This change increases security and reliability by ensuring that the workflows always use a known, fixed version of each action, preventing unexpected changes due to upstream updates.

The most important changes are:

**Security and Reliability Improvements:**

* All instances of `actions/checkout`, `azure/login`, and other third-party actions across workflow files (e.g., `.github/workflows/azd-template-validation.yml`, `.github/workflows/azure-dev.yml`, `.github/workflows/broken-links-checker.yml`, `.github/workflows/daga-automation-oidc.yml`, `.github/workflows/powershell-analyzer.yml`, `.github/workflows/pr-title-checker.yml`, `.github/workflows/stale-bot.yml`) have been updated to reference specific commit SHAs instead of version tags. This ensures that the exact version of each action is used and prevents accidental changes from upstream updates. [[1]](diffhunk://#diff-711c28063a0d1eeaded24f81685f191e9f411f063808c59f668bc8c6f47eeb13L22-R34) [[2]](diffhunk://#diff-b0a856ddf67919f52d7a1db1bc5c4edf96e59c4761717ca93aeb11239456c2d7L25-R36) [[3]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L19-R19) [[4]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L37-R37) [[5]](diffhunk://#diff-67e26d77769066e1f1b5633a89f931c691eabfd57782a0767fa13ebb15319af4L50-R50) [[6]](diffhunk://#diff-6e95258eb2766f0c99972b74a0045d0e9e055e04a838ffc01ee01cfd81d73ec5L30-R33) [[7]](diffhunk://#diff-dff0590e0b8da04463b56e47df74077decc23fa23b16a95f42b998a8124a2d2eL24-R27) [[8]](diffhunk://#diff-dff0590e0b8da04463b56e47df74077decc23fa23b16a95f42b998a8124a2d2eL37-R37) [[9]](diffhunk://#diff-dff0590e0b8da04463b56e47df74077decc23fa23b16a95f42b998a8124a2d2eL47-R47) [[10]](diffhunk://#diff-3a8865ff9962bd48d45f69c2cc23f0151fc5d7512150713996f86cb21309944fL20-R20) [[11]](diffhunk://#diff-7d98caa1d6d6648f3266503a806c5b7dc6214839a1a1fabd7dcaa5c54d72222eL15-R15) [[12]](diffhunk://#diff-7d98caa1d6d6648f3266503a806c5b7dc6214839a1a1fabd7dcaa5c54d72222eL27-R27) [[13]](diffhunk://#diff-7d98caa1d6d6648f3266503a806c5b7dc6214839a1a1fabd7dcaa5c54d72222eL78-R78)

**Workflow Consistency:**

* The update applies consistently across all workflow files, including those for template validation, Azure deployment, broken link checking, OIDC automation, PowerShell analysis, PR title checking, and stale bot management, ensuring a uniform approach to dependency management. (All references above)

No functional changes to workflow logic were made—these updates are focused on pinning action versions for improved security and predictability.
## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->
